### PR TITLE
Dev

### DIFF
--- a/components/layout/DevBuildNotification.vue
+++ b/components/layout/DevBuildNotification.vue
@@ -2,6 +2,8 @@
 import { useEnvironmentNotification } from '../../composables/use-environment-notification'
 
 const { showDevNotification } = useEnvironmentNotification()
+const config = useRuntimeConfig()
+const environment = config.public.vercelDev === 'preview' ? 'preview' : 'development'
 </script>
 
 <template>
@@ -15,7 +17,7 @@ const { showDevNotification } = useEnvironmentNotification()
     <div class="flix items-center gap-2 font-mono text-sm">
       <i class="pi pi-info-circle" />
       <span>
-        You are viewing a development build. Some features may be unfinished or unstable.
+        You are viewing a {{ environment }} build. Some features may be unfinished or unstable.
       </span>
     </div>
   </Message>

--- a/composables/use-environment-notification.ts
+++ b/composables/use-environment-notification.ts
@@ -5,16 +5,7 @@ export function useEnvironmentNotification() {
   const config = useRuntimeConfig()
 
   onMounted(() => {
-    const isDevelopment = config.public.environment === 'development'
-    const currentBranch = config.public.gitBranch || 'unknown'
-
-    console.log({
-      isDevelopment,
-      currentBranch,
-      shouldShow: isDevelopment || (currentBranch && currentBranch !== 'main'),
-    })
-
-    showDevNotification.value = isDevelopment || currentBranch !== 'main'
+    showDevNotification.value = config.public.vercelEnv !== 'production'
   })
 
   return {

--- a/composables/use-environment-notification.ts
+++ b/composables/use-environment-notification.ts
@@ -7,6 +7,13 @@ export function useEnvironmentNotification() {
   onMounted(() => {
     const isDevelopment = config.public.environment === 'development'
     const currentBranch = config.public.gitBranch || 'unknown'
+
+    console.log({
+      isDevelopment,
+      currentBranch,
+      shouldShow: isDevelopment || (currentBranch && currentBranch !== 'main'),
+    })
+
     showDevNotification.value = isDevelopment || currentBranch !== 'main'
   })
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default antfu(
         },
       ],
       'node/prefer-global/process': 'off',
+      'no-console': 'warn',
     },
   },
 )

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,8 +50,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      environment: import.meta.env.NODE_ENV || 'development',
-      gitBranch: import.meta.env.NUXT_PUBLIC_GIT_BRANCH || 'unknown',
+      vercelEnv: import.meta.env.VERCEL_ENV || 'development',
     },
   },
 


### PR DESCRIPTION
This pull request introduces changes to improve the handling of environment configurations and enforce coding standards. The most important changes include updating how the environment is determined and displayed, and adding a new ESLint rule to warn about console usage.

Improvements to environment configuration:

* [`components/layout/DevBuildNotification.vue`](diffhunk://#diff-97b34aaf1e828bece36deb147916b9967205f65c0e6294a0bf9002ef0c7bc758R5-R6): Introduced a new `environment` variable to differentiate between 'preview' and 'development' builds, and updated the notification message to use this variable. [[1]](diffhunk://#diff-97b34aaf1e828bece36deb147916b9967205f65c0e6294a0bf9002ef0c7bc758R5-R6) [[2]](diffhunk://#diff-97b34aaf1e828bece36deb147916b9967205f65c0e6294a0bf9002ef0c7bc758L18-R20)
* [`composables/use-environment-notification.ts`](diffhunk://#diff-4bb44b7c2995e0563cd3dbf78eaa944936904005472ee1941b1b4653cacfb118L8-R8): Simplified the logic to set `showDevNotification` by checking if the environment is not 'production'.
* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L53-R53): Replaced `environment` and `gitBranch` with `vercelEnv` to streamline environment configuration.

Enforcement of coding standards:

* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839R24): Added a rule to warn about the usage of `console` statements to encourage cleaner code.