### PR TITLE
perf ⚡️ Don't lazy-load FCP image

### DIFF
--- a/components/ui/HeroSection.vue
+++ b/components/ui/HeroSection.vue
@@ -81,7 +81,6 @@ onMounted(() => {
               src="/images/akashbagchi.png"
               alt="Developer Icon"
               format="webp"
-              loading="lazy"
               class="h-full w-full rounded-full object-cover transition-transform duration-300"
               sizes="(max-width: 758px) 180px, 300px"
               quality="100"


### PR DESCRIPTION
> [!NOTE] 
> Responds to #19 

### Summary of changes: 

- Stop lazy-loading FCP image in hero section to speed up initial render time

<img width="815" alt="Screenshot 2024-12-13 at 9 55 10 AM" src="https://github.com/user-attachments/assets/d8811ab3-3771-4ec6-be0c-8d3798ac9f93" />
